### PR TITLE
Fix target platform build dependencies

### DIFF
--- a/pde/pom.xml
+++ b/pde/pom.xml
@@ -57,7 +57,7 @@
     <repository>
       <id>lsp4j</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/lsp4j/updates/releases/0.22.0/</url>
+      <url>https://download.eclipse.org/lsp4j/updates/releases/0.23.1/</url>
     </repository>
     </repositories>
     <build>

--- a/pde/target.target
+++ b/pde/target.target
@@ -37,12 +37,12 @@
             <repository location="https://download.eclipse.org/releases/2024-03/" />
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.22.0/" />
+            <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.23.1/" />
             <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0" />
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0" />
-            <repository location="http://download.eclipse.org/jdtls/snapshots/repository/latest/" />
+            <repository location="https://download.eclipse.org/jdtls/milestones/1.40.0/" />
         </location>
     </locations>
 </target>


### PR DESCRIPTION
The latest version of jdtls requires version 0.23.0 of lsp4j. Changing the a snapshot of jdtls instead of latest will prevent version mismatch in future releases.
- Use jdtls from https://download.eclipse.org/jdtls/milestones/1.40.0/ in target platform
- Use lsp4j from https://download.eclipse.org/lsp4j/updates/releases/0.23.1/ in target platform
- Use lsp4j from https://download.eclipse.org/lsp4j/updates/releases/0.23.1/ in pom.xml